### PR TITLE
Fix trigger conditions

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -7,7 +7,12 @@
 
 name: Unit tests
 
-on: [ push ]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
At https://github.com/Diapolo10/iplib3/pull/105 and https://github.com/orgs/community/discussions/26698#discussioncomment-7094600 it was reported, that the unit tests were not triggered on a pull request.

The reason was that the trigger for a pull request was not active. The trigger `pull_request` is used for PRs - see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request for details

Note that the workflow https://github.com/Diapolo10/iplib3/blob/main/.github/workflows/codeql-analysis.yml has the correct triggers.

I also added `workflow_dispatch` to enable manual triggering.